### PR TITLE
Fix to SELU activation function definition.

### DIFF
--- a/mlsurfacelayer/module_neural_net.f90
+++ b/mlsurfacelayer/module_neural_net.f90
@@ -115,7 +115,7 @@ contains
            !     print*, "selu"
                 do i=1,size(input, 1)
                     do j=1, size(input,2)
-                        output(i, j) = selu_lambda * ( dmax1(output(i, j),zero) + dmin1(selu_alpha*(exp(output(i, j))-1.0),zero) )
+                        output(i, j) = selu_lambda * ( dmax1(input(i, j),zero) + dmin1(selu_alpha*(exp(input(i, j))-1.0),zero) )
                     end do
                 end do
             case (5)


### PR DESCRIPTION
We found an issue with the SELU activation function definition during the implementation of the NN algorithm into FastEddy. With this modification we were able to replicate Python's NN model output for the same input in FastEddy. Otherwise, the NN results are several times smaller. The SELU activation function definition was taken from here: 
https://pytorch.org/docs/stable/generated/torch.nn.SELU.html